### PR TITLE
Fix Permission hook deprecation

### DIFF
--- a/civiteams.php
+++ b/civiteams.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'civiteams.civix.php';
+use CRM_Team_ExtensionUtil as E;
 
 /**
  * Implements hook_civicrm_config().
@@ -46,8 +47,12 @@ function civiteams_civicrm_searchTasks($objectType, &$tasks) {
 }
 
 function civiteams_civicrm_permission(&$permissions) {
-  $permissions['access civiteams']     = ts('CiviTeams') . ': ' . ts('Access Team Listing');
-  $permissions['administer civiteams'] = ts('CiviTeams') . ': ' . ts('Administer Teams');
+  $permissions['access civiteams'] = [
+    'label' => E::ts('CiviTeams') . ': ' . E::ts('Access Team Listing'),
+  ];
+  $permissions['administer civiteams'] = [
+    'label' => E::ts('CiviTeams') . ': ' . E::ts('Administer Teams'),
+  ];
 }
 
 /**

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/agileware/au.com.agileware/civiteams/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2023-11-08</releaseDate>
-  <version>1.2</version>
+  <releaseDate>2024-06-19</releaseDate>
+  <version>1.2.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.67</ver>

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2024-06-19</releaseDate>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.67</ver>


### PR DESCRIPTION
```
User deprecated function: Permission 'access civiteams' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions in CRM_Core_Error::deprecatedWarning() (line 1132 of /var/www/html/vendor/civicrm/civicrm-core/CRM/Core/Error.php).
User deprecated function: Permission 'administer civiteams' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions in CRM_Core_Error::deprecatedWarning() (line 1132 of /var/www/html/vendor/civicrm/civicrm-core/CRM/Core/Error.php).
``` 